### PR TITLE
Add equal spacing outside of main stack

### DIFF
--- a/Library/AppearanceSelectionTableCell.m
+++ b/Library/AppearanceSelectionTableCell.m
@@ -108,8 +108,8 @@
         self.containerStackView.translatesAutoresizingMaskIntoConstraints = false;
 
         for (NSDictionary *option in self.options) {
-            AppearanceTypeStackView *stackView = [[AppearanceTypeStackView alloc] initWithType:[self.options indexOfObject:option] 
-                                                                                  forController:self 
+            AppearanceTypeStackView *stackView = [[AppearanceTypeStackView alloc] initWithType:[self.options indexOfObject:option]
+                                                                                  forController:self
                                                                                   withImage:[UIImage imageNamed:option[@"image"] inBundle:prefsBundle compatibleWithTraitCollection:NULL]
                                                                                   andText:option[@"text"]
                                                                                   andSpecifier:specifier];
@@ -138,6 +138,12 @@
         subview.checkmarkButton.selected = subview.type == type;
         subview.checkmarkButton.tintColor = (subview.checkmarkButton.selected) ? (subview.tintColor ? [UIColor colorFromHexString:subview.tintColor] : [UIColor systemBlueColor]) : [UIColor systemGrayColor];
     }
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+
+    if (self.containerStackView.spacing != (self.bounds.size.width - (60 * [self.options count])) / ([self.options count] + 1)) self.containerStackView.spacing = (self.bounds.size.width - (60 * [self.options count])) / ([self.options count] + 1);
 }
 
 @end

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: me.conorthedev.libappearancecell
 Name: libappearancecell
-Version: 1.0.2
+Version: 1.0.3
 Architecture: iphoneos-arm
 Description: A library for that allows developers to use an iOS 13-style appearance selector in their Preferences.
 Maintainer: ConorTheDev <conorthedev@gmail.com>


### PR DESCRIPTION
More reminiscent of iOS 13's appearance selector spacing. Also allows for adding more cells before running into issues, as a product of automatically calculated spacing.